### PR TITLE
Use jdk foojay

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ construo {
     targets {
         create<Target.Linux>("linuxX64") {
             architecture.set(Target.Architecture.X86_64)
-            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_linux_hotspot_17.0.10_7.tar.gz")
+            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz")
         }
         create<Target.MacOs>("macM1") {
             architecture.set(Target.Architecture.AARCH64)
-            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.10_7.tar.gz")
+            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.11_9.tar.gz")
             // macOS needs an identifier
             identifier.set("io.github.fourlastor.Game")
             // Optional: icon for macOS
@@ -114,7 +114,7 @@ construo {
         }
         create<Target.Windows>("winX64") {
             architecture.set(Target.Architecture.X86_64)
-            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.10_7.zip")
+            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.11_9.zip")
             // use executable with GPU hints, defaults to true
             useGpuHint.set(false)
         }
@@ -133,11 +133,11 @@ construo {
     targets.configure {
         create("linuxX64", Target.Linux) {
             architecture.set(Target.Architecture.X86_64)
-            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_linux_hotspot_17.0.10_7.tar.gz")
+            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz")
         }
         create("macM1", Target.MacOs) {
             architecture.set(Target.Architecture.AARCH64)
-            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.10_7.tar.gz")
+            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.11_9.tar.gz")
             // macOS needs an identifier
             identifier.set("io.github.fourlastor.Game")
             // Optional: icon for macOS
@@ -145,7 +145,7 @@ construo {
         }
         create("winX64", Target.Windows) {
             architecture.set(Target.Architecture.X86_64)
-            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.10_7.zip")
+            jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.11_9.zip")
             // use executable with GPU hints, defaults to true
             useGpuHint.set(false)
         }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ construo {
 
 ### JLink options
 
-You can add extra modules to the minimized JRE via the `jlink` block.
+You can add extra modules to the minimized JDK via the `jlink` block.
 
 ```kotlin
 construo {
@@ -78,7 +78,7 @@ construo {
 
 ### Defining targets
 
-Targets define the output bundles construo will generate, each target will need to define the architecture, and an optional (if using the [foojay api](#using-foojay-instead-of-jre-urls)) JRE url for that specific target.
+Targets define the output bundles construo will generate, each target will need to define the architecture, and an optional (if using the [foojay api](#using-foojay-instead-of-jdk-urls)) JDK url for that specific target (you cannot use a JRE for cross compilation).
 
 #### Windows
 
@@ -156,9 +156,9 @@ construo {
 
 Each defined target will generate a `packageXXX` task, where `XXX` is the capitalized name of the target (for example: `packageLinuxX64`). Running the task will produce a zip inside the `outputDir` folder containing the fully packaged app.
 
-### Using foojay instead of JRE URLs
+### Using foojay instead of JDK URLs
 
-Construo can figure out the JRE url for a specific build via the [foojay discovery api](https://github.com/foojayio/discoapi). This makes the `jdkUrl` option inside `targets` optional.
+Construo can figure out the JDK url for a specific build via the [foojay discovery api](https://github.com/foojayio/discoapi). This makes the `jdkUrl` option inside `targets` optional.
 
 ```kotlin
 import io.github.fourlastor.construo.Target
@@ -177,4 +177,4 @@ construo {
 }
 ```
 
-`ToolchainVersion.of()` accepts either a string, which must be a specific JRE version for that vendor, or an integer, which must be a major java version number (ie `ToolchainVersion.of(17)`).
+`ToolchainVersion.of()` accepts either a string, which must be a specific JDK version for that vendor, or an integer, which must be a major java version number (ie `ToolchainVersion.of(17)`).

--- a/construo/src/main/java/io/github/fourlastor/construo/foojay/FooJayClient.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/foojay/FooJayClient.kt
@@ -93,10 +93,7 @@ class FooJayClient {
                 .fromJson(body.source())
         ) { "Packages deserialization returned null" }
             .result
-            .let { packages ->
-                packages.firstOrNull { it.packageType == "jre" }
-                    ?: packages.first()
-            }
+            .let { packages -> packages.first { it.packageType == "jdk" } }
     }
 
     private fun fetchPackageDownloadInfo(jvmPackage: Package) =


### PR DESCRIPTION
Using `jlink` to build a minimized JRE from a JRE won't work cross os, this PR changes the foojay api so it will pick a JDK instead
Also docs have been updated.