### PR TITLE
Allow different jar task

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ construo {
     // Optional, defaults to $buildDir/construo/dist
     // where to put the packaged zips
     outputDir.set(rootProject.file("dist"))
+    // Optional, an alternative jar task name to base the build upon
+    jarTask.set("myJarTaskName")
 }
 ```
 

--- a/construo/src/main/java/io/github/fourlastor/construo/ConstruoPluginExtension.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/ConstruoPluginExtension.kt
@@ -21,6 +21,7 @@ abstract class ConstruoPluginExtension @Inject constructor(
     abstract val outputDir: DirectoryProperty
     abstract val jdkRoot: DirectoryProperty
     abstract val mainClass: Property<String>
+    abstract val jarTask: Property<String>
     val targets: ExtensiblePolymorphicDomainObjectContainer<Target> = objectFactory.polymorphicDomainObjectContainer(Target::class.java)
     val jlink: JlinkOptions = objectFactory.newInstance(JlinkOptions::class.java).apply {
         guessModulesFromJar.convention(true)


### PR DESCRIPTION
This PR add the ability to configure a specific jar task to depend on when packaging with construo.

There are also some minor changes on how `jarTask` and `mainClass` are retrieved. TIL not making everything lazy results in different inputs depending on the order in which the properties are set.

Fixes #57