### PR TITLE
Use custom download task

### DIFF
--- a/construo/build.gradle.kts
+++ b/construo/build.gradle.kts
@@ -63,7 +63,6 @@ gradlePlugin {
 
 dependencies {
     implementation(libs.apache.commons.compress)
-    implementation(libs.download)
     implementation(libs.square.moshi.core)
     ksp(libs.square.moshi.codegen)
     implementation(libs.square.okhttp)

--- a/construo/src/main/java/io/github/fourlastor/construo/task/DownloadTask.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/task/DownloadTask.kt
@@ -1,0 +1,37 @@
+package io.github.fourlastor.construo.task
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.IOUtils
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskExecutionException
+
+abstract class DownloadTask: BaseTask() {
+
+    @get:Input
+    abstract val src: Property<String>
+
+    @get:OutputFile
+    abstract val dest: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val client = OkHttpClient()
+        val result = runCatching { client.newCall(Request.Builder().url(src.get()).build()).execute() }
+        result.onSuccess { response ->
+            if (!response.isSuccessful) {
+                throw TaskExecutionException(this, RuntimeException("${response.request.url} returned failure code ${response.code}"))
+            }
+            requireNotNull(response.body).use {
+                IOUtils.copy(it.byteStream(), FileUtils.openOutputStream(dest.get().asFile))
+            }
+        }.onFailure {
+            throw TaskExecutionException(this, it)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 apache-commons-compress = "1.27.1"
-download = "5.4.0"
 gdx = "1.11.0"
 guardsquare-proguard = "7.5.0"
 jetbrains-kotlin = "1.9.10"
@@ -14,7 +13,6 @@ spotless = "6.10.0"
 xmlBuilder = "1.9.0"
 [libraries]
 apache-commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "apache-commons-compress" }
-download = { module = "de.undercouch:gradle-download-task", version.ref = "download" }
 gdx-core = { module = "com.badlogicgames.gdx:gdx", version.ref = "gdx" }
 gdx-platform = { module = "com.badlogicgames.gdx:gdx-platform", version.ref = "gdx" }
 gdx-backend-lwjgl3 = { module = "com.badlogicgames.gdx:gdx-backend-lwjgl3", version.ref = "gdx" }


### PR DESCRIPTION
https://github.com/michel-kraemer/gradle-download-task `overwriteFile = false` does not work for construo, as it will never override the file, not even if the src url changed. This led to subtle bugs when updating roast from 0.0.7 to 1.1.0, as the api changed and the cached 0.0.7 version would be used instead of downloading the new version (this also is problematic for JDK as changing the JDK without a clean would have no effect)

This PR creates a new `DownloadTask` class which is a much simplified version and works as construo needs cache wise.