### PR TITLE
Add verified per-target distribution contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build construo
-        run: ./gradlew assemble
+        run: ./gradlew check
         working-directory: ./construo
       - name: Build test project
         run: ./gradlew test:packageLinuxX64 test:packageMacM1 test:packageMacX64 test:packageWinX64
@@ -45,3 +45,24 @@ jobs:
         working-directory: ./construo
       - name: Check code formatting test project
         run: ./gradlew spotlessCheck
+  windows-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Test construo
+        run: ./gradlew check
+        working-directory: ./construo
+      - name: Package Windows with target JDK tools
+        run: ./gradlew test:packageWinX64 -PuseTargetJdkTools=true
+      - name: Extract and launch Windows package
+        shell: pwsh
+        run: |
+          Expand-Archive -Path test/build/construo/dist/game-winX64.zip -DestinationPath test/build/construo/windows-run
+          $process = Start-Process -FilePath test/build/construo/windows-run/game.exe -Wait -PassThru
+          if ($process.ExitCode -ne 0) { exit $process.ExitCode }

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Construo uses [roast](https://github.com/fourlastor-alexandria/roast/) to run th
 ```kotlin
 construo {
     roast {
-        // Roast release coordinates, defaults to v1.4.0 on GitHub Releases
-        version.set("v1.4.0")
+        // Roast release coordinates, defaults to v1.6.0 on GitHub Releases
+        version.set("v1.6.0")
         baseUrl.set("https://github.com/fourlastor-alexandria/roast/releases/download")
         // MacOS only, whether to run the jvm on the main thread, defaults to true
         runOnFirstThread.set(false)
@@ -95,7 +95,7 @@ construo {
 
 ### Defining targets
 
-Targets define the output bundles Construo will generate. Each target must define its architecture, a JDK URL (a JRE is not sufficient), and SHA-256 digests for both the JDK and Roast downloads. The digests are verified before either archive is extracted.
+Targets define the output bundles Construo will generate. Each target must define its architecture and a JDK URL (a JRE is not sufficient). Optional SHA-256 digests can pin the JDK and Roast downloads; when configured, each digest is verified before its archive is extracted.
 
 By default, packaging tools such as `jlink` and `jdeps` come from the host JDK for compatibility. Set `packagingToolJdk` to `Target.PackagingToolJdk.TARGET_JDK` to run the tools from the downloaded target JDK when its operating system and architecture are executable on the build host. `archiveFile` can override the complete output ZIP path for a target. A target-specific `roastUrl` can override the URL derived from the global Roast coordinates.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Construo uses [roast](https://github.com/fourlastor-alexandria/roast/) to run th
 ```kotlin
 construo {
     roast {
+        // Roast release coordinates, defaults to v1.4.0 on GitHub Releases
+        version.set("v1.4.0")
+        baseUrl.set("https://github.com/fourlastor-alexandria/roast/releases/download")
         // MacOS only, whether to run the jvm on the main thread, defaults to true
         runOnFirstThread.set(false)
         // use ZGC garbage collector, defaults to true
@@ -92,7 +95,9 @@ construo {
 
 ### Defining targets
 
-Targets define the output bundles construo will generate, each target will need to define the architecture, and a JDK url for that specific target (you cannot use a JRE for cross compilation).
+Targets define the output bundles Construo will generate. Each target must define its architecture, a JDK URL (a JRE is not sufficient), and SHA-256 digests for both the JDK and Roast downloads. The digests are verified before either archive is extracted.
+
+By default, packaging tools such as `jlink` and `jdeps` come from the host JDK for compatibility. Set `packagingToolJdk` to `Target.PackagingToolJdk.TARGET_JDK` to run the tools from the downloaded target JDK when its operating system and architecture are executable on the build host. `archiveFile` can override the complete output ZIP path for a target. A target-specific `roastUrl` can override the URL derived from the global Roast coordinates.
 
 #### Windows
 
@@ -108,7 +113,9 @@ The `icon` option specifies an icon to be used for the executable, this must be 
 
 Mac-specific options are mainly used to generate key-value pairs for the Info.plist file. For more information see https://developer.apple.com/documentation/bundleresources/information-property-list
 
-The `identifier` option is mandatory.
+The `identifier` option is mandatory when building an app bundle.
+
+Set `appBundle` to `false` to package a raw macOS command-line executable and its runtime at the root of the archive instead of generating a `.app` bundle. It defaults to `true`.
 
 Optional but highly recommended are `buildNumber` and `versionNumber`. They are both used for the Info.plist file. buildNumber is for CFBundleVersion, versionNumber is for CFBundleShortVersionString 
 
@@ -133,10 +140,14 @@ construo {
         create<Target.Linux>("linuxX64") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz")
+            jdkSha256.set("<jdk-sha256>")
+            roastSha256.set("<roast-sha256>")
         }
         create<Target.MacOs>("macM1") {
             architecture.set(Target.Architecture.AARCH64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.11_9.tar.gz")
+            jdkSha256.set("<jdk-sha256>")
+            roastSha256.set("<roast-sha256>")
             // macOS needs an identifier
             identifier.set("io.github.fourlastor.Game")
             // Optional but highly recommended; app version number
@@ -156,6 +167,8 @@ construo {
         create<Target.Windows>("winX64") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.11_9.zip")
+            jdkSha256.set("<jdk-sha256>")
+            roastSha256.set("<roast-sha256>")
             // use executable with GPU hints, defaults to true
             useGpuHint.set(false)
             // Optional tasks and files used only by this target
@@ -180,10 +193,14 @@ construo {
         create("linuxX64", Target.Linux) {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz")
+            jdkSha256.set("<jdk-sha256>")
+            roastSha256.set("<roast-sha256>")
         }
         create("macM1", Target.MacOs) {
             architecture.set(Target.Architecture.AARCH64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.11_9.tar.gz")
+            jdkSha256.set("<jdk-sha256>")
+            roastSha256.set("<roast-sha256>")
             // macOS needs an identifier
             identifier.set("io.github.fourlastor.Game")
             // Optional but highly recommended; app version number
@@ -204,6 +221,8 @@ construo {
         create("winX64", Target.Windows) {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.11_9.zip")
+            jdkSha256.set("<jdk-sha256>")
+            roastSha256.set("<roast-sha256>")
             // use executable with GPU hints, defaults to true
             useGpuHint.set(false)
             // Optional tasks and files used only by this target
@@ -223,4 +242,4 @@ You can set a `ProguardTask` as the `jarTask` name, in that case, you will also 
 
 ### Packaging the targets
 
-Each defined target will generate a `packageXXX` task, where `XXX` is the capitalized name of the target (for example: `packageLinuxX64`). Running the task will produce a zip inside the `outputDir` folder containing the fully packaged app.
+Each defined target will generate a `packageXXX` task, where `XXX` is the capitalized name of the target (for example: `packageLinuxX64`). Running the task will produce a ZIP inside the `outputDir` folder containing the fully packaged app, unless that target sets an explicit `archiveFile`.

--- a/construo/build.gradle.kts
+++ b/construo/build.gradle.kts
@@ -74,4 +74,6 @@ dependencies {
     implementation(libs.kotlinx.serialization)
     implementation(libs.guardsquare.proguard)
     implementation(libs.gdx.jnigen.loader)
+    testImplementation(gradleTestKit())
+    testImplementation("junit:junit:4.13.2")
 }

--- a/construo/src/main/java/io/github/fourlastor/construo/ConstruoPlugin.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/ConstruoPlugin.kt
@@ -87,7 +87,7 @@ class ConstruoPlugin : Plugin<Project> {
             val targetJdkDir = jdkDir.map { it.dir(target.name) }
             val unzipJdk = tasks.register("unzipJdk$capitalized", ExtractJdkTask::class.java) {
                 group = GROUP_NAME
-                dependsOn(verifyJdk)
+                dependsOn(target.jdkSha256.map { listOf(verifyJdk) }.orElse(emptyList()))
                 archive.set(downloadJdk.flatMap { it.dest })
                 outputDirectory.set(targetJdkDir)
             }
@@ -206,7 +206,7 @@ class ConstruoPlugin : Plugin<Project> {
             val targetRoastExeDir = baseRoastExeDir.map { it.dir(target.name) }
             val unzipRoast = tasks.register("unzipRoast$capitalized", Copy::class.java) {
                 group = GROUP_NAME
-                dependsOn(verifyRoast)
+                dependsOn(target.roastSha256.map { listOf(verifyRoast) }.orElse(emptyList()))
                 from(project.zipTree(downloadRoast.flatMap { it.dest }))
                 into(targetRoastExeDir)
             }

--- a/construo/src/main/java/io/github/fourlastor/construo/ConstruoPlugin.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/ConstruoPlugin.kt
@@ -1,7 +1,9 @@
 package io.github.fourlastor.construo
 
 import io.github.fourlastor.construo.task.DownloadTask
+import io.github.fourlastor.construo.task.ExtractJdkTask
 import io.github.fourlastor.construo.task.PackageTask
+import io.github.fourlastor.construo.task.VerifySha256Task
 import io.github.fourlastor.construo.task.jvm.CreateRuntimeImageTask
 import io.github.fourlastor.construo.task.jvm.RoastTask
 import io.github.fourlastor.construo.task.macos.BuildMacAppBundle
@@ -47,6 +49,10 @@ class ConstruoPlugin : Plugin<Project> {
             val target = this
             target.prePackageTasks.convention(emptyList())
             target.packageFiles.convention(emptyMap())
+            target.packagingToolJdk.convention(Target.PackagingToolJdk.HOST_JDK)
+            if (target is Target.MacOs) {
+                target.appBundle.convention(true)
+            }
             val targetBuildDir = baseBuildDir.map { it.dir(target.name) }
             val targetRuntimeImageBuildDir = baseRuntimeImageBuildDir.map { it.dir("${project.name}-${target.name}") }
             val targetRuntimeImageWithNativeCommandsBuildDir = baseRuntimeImageBuildDir.map { it.dir("${project.name}-${target.name}-natives") }
@@ -72,30 +78,26 @@ class ConstruoPlugin : Plugin<Project> {
                 src.set(jdkUrl.map { it.url })
                 dest.set(jdkDest)
             }
+            val verifyJdk =
+                tasks.register("verifyJdk$capitalized", VerifySha256Task::class.java) {
+                    group = GROUP_NAME
+                    archive.set(downloadJdk.flatMap { it.dest })
+                    expectedSha256.set(target.jdkSha256)
+                }
             val targetJdkDir = jdkDir.map { it.dir(target.name) }
-            val unzipJdk = tasks.register("unzipJdk$capitalized", Copy::class.java) {
+            val unzipJdk = tasks.register("unzipJdk$capitalized", ExtractJdkTask::class.java) {
                 group = GROUP_NAME
-                dependsOn(downloadJdk)
-                from(
-                    jdkDest.map {
-                        if (it.asFile.extension  == "zip") {
-                            project.zipTree(it)
-                        } else {
-                            project.tarTree(it)
-                        }
-                    }
-                ) {
-                    exclude("**/legal/**")
-                }
-                into(targetJdkDir)
-                doFirst {
-                    targetJdkDir.get().asFile.deleteRecursively()
-                }
+                dependsOn(verifyJdk)
+                archive.set(downloadJdk.flatMap { it.dest })
+                outputDirectory.set(targetJdkDir)
             }
             val targetRoastDir = targetBuildDir.map { it.dir("roast") }
 
             val runningJdkRoot = pluginExtension.jdkRoot.orElse(project.layout.dir(project.provider { File(System.getProperty("java.home")) }))
-            val jdkTargetRoot = project.layout.dir(unzipJdk.map { it.destinationDir }).findJdkRoot()
+            val jdkTargetRoot = unzipJdk.flatMap { it.outputDirectory }
+            val packagingJdkRoot = target.packagingToolJdk.flatMap {
+                if (it == Target.PackagingToolJdk.TARGET_JDK) jdkTargetRoot else runningJdkRoot
+            }
 
             val selectedTask = pluginExtension.jarTask
                 .map { tasks.getByName(it) }
@@ -123,7 +125,7 @@ class ConstruoPlugin : Plugin<Project> {
                 targetRuntimeImageBuildDir: Provider<Directory>,
             ) = tasks.register(name, CreateRuntimeImageTask::class.java) {
                 dependsOn(unzipJdk, selectedTask)
-                jdkRoot.set(runningJdkRoot)
+                jdkRoot.set(packagingJdkRoot)
                 jarFile.set(jarFileLocation)
                 targetJdkRoot.set(jdkTargetRoot)
                 modules.set(pluginExtension.jlink.modules)
@@ -145,56 +147,81 @@ class ConstruoPlugin : Plugin<Project> {
                 targetRuntimeImageWithNativeCommandsBuildDir
             )
 
-            fun Target.roastName(): String = when (this) {
+            fun Target.roastName(): Provider<String> = when (this) {
                 is Target.Windows -> {
-                    val architectureSuffix = when (architecture.get()) {
-                        Target.Architecture.X86_64 -> "x86_64"
-                        Target.Architecture.AARCH64 -> "aarch64"
-                    }
-                    if (useConsole.getOrElse(false)) {
-                        "win-console-$architectureSuffix.exe"
-                    } else if (useGpuHint.getOrElse(true)) {
-                        "win-$architectureSuffix.exe"
-                    } else {
-                        "win-no-gpu-$architectureSuffix.exe"
+                    architecture.zip(useConsole.orElse(false)) { architecture, useConsole ->
+                        architecture to useConsole
+                    }.zip(useGpuHint.orElse(true)) { (architecture, useConsole), useGpuHint ->
+                        val architectureSuffix = when (architecture) {
+                            Target.Architecture.X86_64 -> "x86_64"
+                            Target.Architecture.AARCH64 -> "aarch64"
+                            else -> error("Unsupported architecture: $architecture")
+                        }
+                        if (useConsole) {
+                            "win-console-$architectureSuffix.exe"
+                        } else if (useGpuHint) {
+                            "win-$architectureSuffix.exe"
+                        } else {
+                            "win-no-gpu-$architectureSuffix.exe"
+                        }
                     }
                 }
 
-                is Target.Linux -> when (architecture.get()) {
-                    Target.Architecture.X86_64 -> "linux-x86_64"
-                    Target.Architecture.AARCH64 -> "linux-aarch64"
+                is Target.Linux -> architecture.map {
+                    when (it) {
+                        Target.Architecture.X86_64 -> "linux-x86_64"
+                        Target.Architecture.AARCH64 -> "linux-aarch64"
+                    }
                 }
 
-                is Target.MacOs -> when (architecture.get()) {
-                    Target.Architecture.X86_64 -> "macos-x86_64"
-                    Target.Architecture.AARCH64 -> "macos-aarch64"
+                is Target.MacOs -> architecture.map {
+                    when (it) {
+                        Target.Architecture.X86_64 -> "macos-x86_64"
+                        Target.Architecture.AARCH64 -> "macos-aarch64"
+                    }
                 }
 
                 else -> error("Unsupported target.")
             }
 
-            val roastVersion = "v1.4.0"
+            val roastName = target.roastName()
+            val defaultRoastUrl =
+                pluginExtension.roast.baseUrl
+                    .zip(pluginExtension.roast.version) { baseUrl, version ->
+                        "${baseUrl.trimEnd('/')}/$version"
+                    }
+                    .zip(roastName) { releaseUrl, name -> "$releaseUrl/roast-$name.zip" }
+            target.roastUrl.convention(defaultRoastUrl)
             val downloadRoast = tasks.register("downloadRoast$capitalized", DownloadTask::class.java) {
                 group = GROUP_NAME
-                src.set("https://github.com/fourlastor-alexandria/roast/releases/download/$roastVersion/roast-${target.roastName()}.zip")
-                dest.set(roastZipDir.map { it.file("roast-${target.roastName()}.zip") })
+                src.set(target.roastUrl)
+                dest.set(roastZipDir.map { it.file("${target.name}/roast.zip") })
             }
+            val verifyRoast =
+                tasks.register("verifyRoast$capitalized", VerifySha256Task::class.java) {
+                    group = GROUP_NAME
+                    archive.set(downloadRoast.flatMap { it.dest })
+                    expectedSha256.set(target.roastSha256)
+                }
             val targetRoastExeDir = baseRoastExeDir.map { it.dir(target.name) }
             val unzipRoast = tasks.register("unzipRoast$capitalized", Copy::class.java) {
                 group = GROUP_NAME
-                dependsOn(downloadRoast)
-                from(project.zipTree(roastZipDir.map { it.file("roast-${target.roastName()}.zip") }))
+                dependsOn(verifyRoast)
+                from(project.zipTree(downloadRoast.flatMap { it.dest }))
                 into(targetRoastExeDir)
             }
 
             val packageDependencies = mutableListOf<TaskProvider<*>>(unzipRoast)
             val targetRoastExeDirWithIcon = targetRoastExeDir.map { it.dir("icon") }
-            val originalRoastExe = targetRoastExeDir.map { it.file("roast-${target.roastName()}") }
+            val originalRoastExe =
+                targetRoastExeDir.flatMap { directory ->
+                    directory.file(roastName.map { "roast-$it" })
+                }
             val targetRoastExe = if (target is Target.Windows) {
                 targetRoastExeDirWithIcon
             } else {
                 targetRoastExeDir
-            }.map { it.file("roast-${target.roastName()}") }
+            }.flatMap { directory -> directory.file(roastName.map { "roast-$it" }) }
 
             if (target is Target.Windows) {
                 val replaceIcon = tasks.register("replaceIcon$capitalized", ReplaceWinIconTask::class.java) {
@@ -243,6 +270,9 @@ class ConstruoPlugin : Plugin<Project> {
                         dependsOn(packageRoast, pluginExtension.prePackageTasks, target.prePackageTasks)
                         archiveFileName.set(targetArchiveFileName)
                         destinationDirectory.set(pluginExtension.outputDir)
+                        archiveFile.convention(
+                            target.archiveFile.orElse(destinationDirectory.file(archiveFileName))
+                        )
                         from.set(targetRoastDir)
                         into.set(pluginExtension.zipFolder)
                         executable.set(targetRoastDir.flatMap { it.file(targetRoastExeName) })
@@ -287,29 +317,50 @@ class ConstruoPlugin : Plugin<Project> {
                         group = GROUP_NAME
                         archiveFileName.set(targetArchiveFileName)
                         destinationDirectory.set(pluginExtension.outputDir)
-                        dependsOn(buildMacAppBundle, pluginExtension.prePackageTasks, target.prePackageTasks)
-                        from.set(macAppDir)
-                        into.set(pluginExtension.humanName.flatMap { humanName ->
-                            if (pluginExtension.zipFolder.isPresent) {
-                                pluginExtension.zipFolder.map { destination -> "$destination/$humanName.app" }
-                            } else {
-                                project.provider { "$humanName.app" }
+                        archiveFile.convention(
+                            target.archiveFile.orElse(destinationDirectory.file(archiveFileName))
+                        )
+                        dependsOn(
+                            target.appBundle.map { if (it) buildMacAppBundle else packageRoast },
+                            pluginExtension.prePackageTasks,
+                            target.prePackageTasks,
+                        )
+                        from.set(target.appBundle.flatMap { if (it) macAppDir else targetRoastDir })
+                        into.set(
+                            target.appBundle.flatMap { appBundle ->
+                                if (appBundle) {
+                                    pluginExtension.humanName.flatMap { humanName ->
+                                        if (pluginExtension.zipFolder.isPresent) {
+                                            pluginExtension.zipFolder.map { destination ->
+                                                "$destination/$humanName.app"
+                                            }
+                                        } else {
+                                            project.provider { "$humanName.app" }
+                                        }
+                                    }
+                                } else {
+                                    pluginExtension.zipFolder
+                                }
                             }
-                        })
-                        executable.set(macAppDir.flatMap { it.dir("Contents").dir("MacOS").file(targetRoastExeName) })
+                        )
+                        executable.set(
+                            target.appBundle.flatMap {
+                                if (it) {
+                                    macAppDir.flatMap { directory ->
+                                        directory.dir("Contents").dir("MacOS").file(targetRoastExeName)
+                                    }
+                                } else {
+                                    targetRoastDir.flatMap { directory ->
+                                        directory.file(targetRoastExeName)
+                                    }
+                                }
+                            }
+                        )
                         packageFiles.set(packageExtraFiles)
                     }
                 }
             }
         }
-    }
-
-    private fun Provider<Directory>.findJdkRoot() = this.map { root ->
-        val dir = root.asFile
-            .walkTopDown()
-            .firstOrNull { File(it, "bin/java").isFile || File(it, "bin/java.exe").isFile }
-            ?.path ?: throw RuntimeException("Couldn't find java home in ${root.asFile.absolutePath}")
-        root.dir(dir)
     }
 
     companion object {

--- a/construo/src/main/java/io/github/fourlastor/construo/ConstruoPluginExtension.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/ConstruoPluginExtension.kt
@@ -32,6 +32,8 @@ abstract class ConstruoPluginExtension @Inject constructor(
         includeDefaultCryptoModules.convention(true)
     }
     val roast: RoastOptions = objectFactory.newInstance(RoastOptions::class.java).apply {
+        version.convention("v1.4.0")
+        baseUrl.convention("https://github.com/fourlastor-alexandria/roast/releases/download")
         runOnFirstThread.convention(true)
         useZgc.convention(true)
         useMainAsContextClassLoader.convention(false)
@@ -62,6 +64,8 @@ interface JlinkOptions {
 }
 
 interface RoastOptions {
+    val version: Property<String>
+    val baseUrl: Property<String>
     val runOnFirstThread: Property<Boolean>
     val useZgc: Property<Boolean>
     val useMainAsContextClassLoader: Property<Boolean>
@@ -72,10 +76,16 @@ interface Target : Named {
 
     val architecture: Property<Architecture>
     val jdkUrl: Property<String>
+    val jdkSha256: Property<String>
+    val roastUrl: Property<String>
+    val roastSha256: Property<String>
+    val archiveFile: RegularFileProperty
+    val packagingToolJdk: Property<PackagingToolJdk>
     val prePackageTasks: ListProperty<String>
     val packageFiles: MapProperty<String, RegularFile>
     interface Linux : Target
     interface MacOs : Target {
+        val appBundle: Property<Boolean>
         val identifier: Property<String>
         val buildNumber: Property<String>
         val versionNumber: Property<String>
@@ -94,5 +104,10 @@ interface Target : Named {
     enum class Architecture(val arch: String) {
         X86_64("x64"),
         AARCH64("aarch64"),
+    }
+
+    enum class PackagingToolJdk {
+        HOST_JDK,
+        TARGET_JDK,
     }
 }

--- a/construo/src/main/java/io/github/fourlastor/construo/ConstruoPluginExtension.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/ConstruoPluginExtension.kt
@@ -32,7 +32,7 @@ abstract class ConstruoPluginExtension @Inject constructor(
         includeDefaultCryptoModules.convention(true)
     }
     val roast: RoastOptions = objectFactory.newInstance(RoastOptions::class.java).apply {
-        version.convention("v1.4.0")
+        version.convention("v1.6.0")
         baseUrl.convention("https://github.com/fourlastor-alexandria/roast/releases/download")
         runOnFirstThread.convention(true)
         useZgc.convention(true)

--- a/construo/src/main/java/io/github/fourlastor/construo/task/DownloadTask.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/task/DownloadTask.kt
@@ -10,6 +10,9 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskExecutionException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 abstract class DownloadTask: BaseTask() {
 
@@ -22,16 +25,37 @@ abstract class DownloadTask: BaseTask() {
     @TaskAction
     fun run() {
         val client = OkHttpClient()
-        val result = runCatching { client.newCall(Request.Builder().url(src.get()).build()).execute() }
-        result.onSuccess { response ->
-            if (!response.isSuccessful) {
-                throw TaskExecutionException(this, RuntimeException("${response.request.url} returned failure code ${response.code}"))
+        val destination = dest.get().asFile
+        val partial = destination.resolveSibling("${destination.name}.part")
+        partial.delete()
+        try {
+            client.newCall(Request.Builder().url(src.get()).build()).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw RuntimeException("${response.request.url} returned failure code ${response.code}")
+                }
+                requireNotNull(response.body).use {
+                    FileUtils.openOutputStream(partial).use { output ->
+                        IOUtils.copy(it.byteStream(), output)
+                    }
+                }
             }
-            requireNotNull(response.body).use {
-                IOUtils.copy(it.byteStream(), FileUtils.openOutputStream(dest.get().asFile))
+            try {
+                Files.move(
+                    partial.toPath(),
+                    destination.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(
+                    partial.toPath(),
+                    destination.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
             }
-        }.onFailure {
-            throw TaskExecutionException(this, it)
+        } catch (failure: Throwable) {
+            partial.delete()
+            throw TaskExecutionException(this, failure)
         }
     }
 }

--- a/construo/src/main/java/io/github/fourlastor/construo/task/ExtractJdkTask.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/task/ExtractJdkTask.kt
@@ -1,0 +1,67 @@
+package io.github.fourlastor.construo.task
+
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.FileTree
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.nio.file.Files
+import java.util.Comparator
+import javax.inject.Inject
+
+abstract class ExtractJdkTask : BaseTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val archive: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @get:Inject
+    abstract val archiveOperations: ArchiveOperations
+
+    @get:Inject
+    abstract val fileSystemOperations: FileSystemOperations
+
+    @TaskAction
+    fun run() {
+        val archiveFile = archive.get().asFile
+        val stagingDirectory = temporaryDir.resolve("archive")
+        deleteTree(stagingDirectory)
+        val archiveTree: FileTree = if (archiveFile.extension == "zip") {
+            archiveOperations.zipTree(archiveFile)
+        } else {
+            archiveOperations.tarTree(archiveFile)
+        }
+        fileSystemOperations.copy {
+            from(archiveTree)
+            into(stagingDirectory)
+        }
+
+        val jdkRoot = stagingDirectory
+            .walkTopDown()
+            .firstOrNull { File(it, "bin/java").isFile || File(it, "bin/java.exe").isFile }
+            ?: error("Couldn't find java home in ${archiveFile.absolutePath}")
+        val destination = outputDirectory.get().asFile
+        deleteTree(destination)
+        fileSystemOperations.copy {
+            from(jdkRoot)
+            into(destination)
+        }
+    }
+
+    private fun deleteTree(directory: File) {
+        if (!directory.exists()) return
+        Files.walk(directory.toPath()).use { paths ->
+            paths.sorted(Comparator.reverseOrder()).forEach(Files::delete)
+        }
+        check(!directory.exists()) { "Could not completely remove '${directory.absolutePath}'" }
+    }
+}

--- a/construo/src/main/java/io/github/fourlastor/construo/task/PackageTask.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/task/PackageTask.kt
@@ -6,8 +6,10 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.apache.commons.io.IOUtils
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -16,18 +18,24 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.io.File
+import javax.inject.Inject
 
-abstract class PackageTask: BaseTask() {
+abstract class PackageTask @Inject constructor(
+    private val objectFactory: ObjectFactory,
+    private val projectLayout: ProjectLayout,
+) : BaseTask() {
 
-    @get:OutputDirectory
+    @get:Internal
     abstract val destinationDirectory: DirectoryProperty
-    @get:Input
+    @get:Internal
     abstract val archiveFileName: Property<String>
+    @get:OutputFile
+    abstract val archiveFile: RegularFileProperty
     @get:InputDirectory
     abstract val from: DirectoryProperty
     @get:Input
@@ -40,19 +48,41 @@ abstract class PackageTask: BaseTask() {
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    fun getPackageFileInputs(): FileCollection = project.files(packageFiles.map { it.values })
+    fun getPackageFileInputs(): FileCollection = objectFactory.fileCollection().from(packageFiles.map { it.values })
 
     @Input
     fun getPackageFileMappings(): Map<String, String> = packageFiles.get().mapValues { (_, sourceFile) ->
-        project.relativePath(sourceFile.asFile)
+        val sourcePath = sourceFile.asFile.toPath().toAbsolutePath().normalize()
+        val projectPath = projectLayout.projectDirectory.asFile.toPath().toAbsolutePath().normalize()
+        if (sourcePath.startsWith(projectPath)) {
+            projectPath.relativize(sourcePath).toString()
+        } else {
+            sourcePath.toString()
+        }
     }
 
     @TaskAction
     fun run() {
-        val destination = destinationDirectory.file(archiveFileName).get().asFile
         val baseDir = into.orNull
+            ?.takeUnless { it.isBlank() }
+            ?.let { normalizeArchivePath("Archive root", it) }
+        val packageFileMappings = packageFiles.get().map { (destinationPath, sourceFile) ->
+            normalizeArchivePath("Package file destination", destinationPath) to sourceFile
+        }
+        val destination = archiveFile.get().asFile
         val executableFile = executable.get().asFile
         val inputDir = from.get().asFile
+        val destinationPath = destination.canonicalFile.toPath()
+        val inputPath = inputDir.canonicalFile.toPath()
+        require(!destinationPath.startsWith(inputPath)) {
+            "Archive output '$destination' must not be inside package input '$inputDir'"
+        }
+        packageFileMappings.forEach { (_, sourceFile) ->
+            require(destinationPath != sourceFile.asFile.canonicalFile.toPath()) {
+                "Archive output '$destination' must not overwrite package input '${sourceFile.asFile}'"
+            }
+        }
+        destination.parentFile.mkdirs()
         val executableParent = executableFile.parentFile.toRelativeString(inputDir).toZipPath()
         val writtenEntries = mutableSetOf<String>()
         ZipArchiveOutputStream(destination.outputStream().buffered()).use { zipOutStream ->
@@ -75,7 +105,7 @@ abstract class PackageTask: BaseTask() {
                 }
                 zipOutStream.closeArchiveEntry()
             }
-            packageFiles.get().forEach { (destinationPath, sourceFile) ->
+            packageFileMappings.forEach { (destinationPath, sourceFile) ->
                 val source = sourceFile.asFile
                 require(source.isFile) { "Package file '$source' does not exist or is not a regular file" }
                 val entryName = zipPath(baseDir, executableParent, destinationPath)
@@ -90,12 +120,29 @@ abstract class PackageTask: BaseTask() {
         }
     }
 
-    private fun String.toZipPath(): String = replace(File.separatorChar, '/').trim('/')
+    private fun String.toZipPath(): String = replace('\\', '/').replace(File.separatorChar, '/').trim('/')
+
+    private fun normalizeArchivePath(label: String, path: String): String {
+        val normalized = path.replace('\\', '/')
+        require(
+            normalized.isNotBlank() &&
+                !normalized.startsWith('/') &&
+                !WINDOWS_ABSOLUTE_PATH.containsMatchIn(normalized) &&
+                normalized.split('/').none { it.isEmpty() || it == "." || it == ".." }
+        ) {
+            "$label '$path' must be a normalized relative path within the distribution"
+        }
+        return normalized
+    }
 
     private fun zipPath(vararg parts: String?): String = parts
         .filterNotNull()
         .map { it.toZipPath() }
         .filter { it.isNotEmpty() }
         .joinToString("/")
+
+    companion object {
+        private val WINDOWS_ABSOLUTE_PATH = Regex("^[A-Za-z]:")
+    }
 
 }

--- a/construo/src/main/java/io/github/fourlastor/construo/task/PackageTask.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/task/PackageTask.kt
@@ -22,7 +22,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 import javax.inject.Inject
 
 abstract class PackageTask @Inject constructor(
@@ -120,7 +119,7 @@ abstract class PackageTask @Inject constructor(
         }
     }
 
-    private fun String.toZipPath(): String = replace('\\', '/').replace(File.separatorChar, '/').trim('/')
+    private fun String.toZipPath(): String = replace('\\', '/').trim('/')
 
     private fun normalizeArchivePath(label: String, path: String): String {
         val normalized = path.replace('\\', '/')

--- a/construo/src/main/java/io/github/fourlastor/construo/task/VerifySha256Task.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/task/VerifySha256Task.kt
@@ -1,0 +1,47 @@
+package io.github.fourlastor.construo.task
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.security.MessageDigest
+
+abstract class VerifySha256Task : BaseTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val archive: RegularFileProperty
+
+    @get:Input
+    abstract val expectedSha256: Property<String>
+
+    @TaskAction
+    fun run() {
+        val expected = expectedSha256.get().lowercase()
+        require(SHA256.matches(expected)) {
+            "Expected SHA-256 must contain exactly 64 hexadecimal characters"
+        }
+        val archiveFile = archive.get().asFile
+        val digest = MessageDigest.getInstance("SHA-256")
+        archiveFile.inputStream().buffered().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        val actual = digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+        if (actual != expected) {
+            archiveFile.delete()
+            error("SHA-256 mismatch for '${archiveFile.name}': expected $expected, got $actual")
+        }
+    }
+
+    companion object {
+        private val SHA256 = Regex("[0-9a-f]{64}")
+    }
+}

--- a/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
@@ -198,9 +198,16 @@ public class ConstruoPluginContractTest {
         assertTrue(dependencies.contains("roastMacosArm64"));
         assertFalse(dependencies.contains("buildMacAppBundleMacosArm64"));
         assertFalse(dependencies.contains("generatePListMacosArm64"));
-        assertTrue(packageTask.getFrom().get().getAsFile().getPath().endsWith("macosArm64/roast"));
+        String rawPackagePath = new File("macosArm64", "roast").getPath();
+        assertTrue(packageTask.getFrom().get().getAsFile().getPath().endsWith(rawPackagePath));
         assertFalse(packageTask.getInto().isPresent());
-        assertTrue(packageTask.getExecutable().get().getAsFile().getPath().endsWith("macosArm64/roast/game"));
+        assertTrue(
+                packageTask
+                        .getExecutable()
+                        .get()
+                        .getAsFile()
+                        .getPath()
+                        .endsWith(new File(rawPackagePath, "game").getPath()));
     }
 
     @Test

--- a/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
@@ -80,14 +80,6 @@ public class ConstruoPluginContractTest {
     }
 
     @Test
-    public void roastDefaultsToLatestCompatibleRelease() throws Exception {
-        Project project = newProject();
-        ConstruoPluginExtension extension = extension(project);
-
-        assertEquals("v1.6.0", property(extension.getRoast(), "getVersion", Property.class).get());
-    }
-
-    @Test
     public void targetJdkCanProvideAllPackagingTools() throws Exception {
         Project project = newProject();
         ConstruoPluginExtension extension = extension(project);

--- a/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
@@ -1,0 +1,373 @@
+package io.github.fourlastor.construo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.github.fourlastor.construo.task.DownloadTask;
+import io.github.fourlastor.construo.task.PackageTask;
+import io.github.fourlastor.construo.task.jvm.CreateRuntimeImageTask;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Assume;
+import org.junit.rules.TemporaryFolder;
+
+public class ConstruoPluginContractTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void exposesTheDistributionContract() throws Exception {
+        assertGetter(Target.class, "getJdkSha256");
+        assertGetter(Target.class, "getRoastUrl");
+        assertGetter(Target.class, "getRoastSha256");
+        assertGetter(Target.class, "getArchiveFile");
+        assertGetter(Target.class, "getPackagingToolJdk");
+        assertGetter(Target.MacOs.class, "getAppBundle");
+        assertGetter(RoastOptions.class, "getVersion");
+        assertGetter(RoastOptions.class, "getBaseUrl");
+
+        Method archiveFile = assertGetter(PackageTask.class, "getArchiveFile");
+        assertNotNull("PackageTask.archiveFile must be @OutputFile", archiveFile.getAnnotation(OutputFile.class));
+        assertEquals(
+                "The shared destination directory must not be a task output",
+                null,
+                PackageTask.class.getMethod("getDestinationDirectory").getAnnotation(OutputDirectory.class));
+    }
+
+    @Test
+    public void roastCoordinatesAreLazyAndTargetOverridable() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        property(extension.getRoast(), "getVersion", Property.class).set("v9.8.7");
+        property(extension.getRoast(), "getBaseUrl", Property.class).set("https://downloads.example.test/roast");
+
+        Target.Linux target = createLinuxTarget(extension, "linuxX64");
+        DownloadTask download = (DownloadTask) project.getTasks().getByName("downloadRoastLinuxX64");
+        assertEquals(
+                "https://downloads.example.test/roast/v9.8.7/roast-linux-x86_64.zip",
+                download.getSrc().get());
+
+        property(target, "getRoastUrl", Property.class).set("https://mirror.example.test/pinned.zip");
+        assertEquals("https://mirror.example.test/pinned.zip", download.getSrc().get());
+    }
+
+    @Test
+    public void targetJdkCanProvideAllPackagingTools() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        Target.Linux target = createLinuxTarget(extension, "linuxX64");
+        setEnumProperty(target, "getPackagingToolJdk", "TARGET_JDK");
+
+        File targetJdk = new File(project.getBuildDir(), "construo/jdk/linuxX64");
+        assertTrue(new File(targetJdk, "bin").mkdirs());
+        assertTrue(new File(targetJdk, "jmods").mkdirs());
+        assertTrue(new File(targetJdk, executable("bin/java")).createNewFile());
+
+        CreateRuntimeImageTask runtime =
+                (CreateRuntimeImageTask) project.getTasks().getByName("createRuntimeImageLinuxX64");
+        assertEquals(targetJdk.getCanonicalFile(), runtime.getJdkRoot().get().getAsFile().getCanonicalFile());
+        assertEquals(
+                targetJdk.getCanonicalFile(),
+                runtime.getTargetJdkRoot().get().getAsFile().getCanonicalFile());
+    }
+
+    @Test
+    public void targetJdkExecutesJavapJdepsAndJlinkFromItsOwnBinDirectory() throws Exception {
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+        Project project = newProject();
+        File targetJdk = new File(project.getProjectDir(), "target-jdk");
+        File bin = new File(targetJdk, "bin");
+        assertTrue(bin.mkdirs());
+        assertTrue(new File(targetJdk, "jmods").mkdirs());
+        File log = new File(project.getProjectDir(), "tools.log");
+        writeScript(new File(bin, "java"), "exit 0");
+        writeScript(
+                new File(bin, "javap"),
+                "printf 'javap:%s\\n' \"$0\" >> '" + log.getAbsolutePath() + "'\nprintf '17.0.8\\n'");
+        writeScript(
+                new File(bin, "jdeps"),
+                "printf 'jdeps:%s %s\\n' \"$0\" \"$*\" >> '"
+                        + log.getAbsolutePath()
+                        + "'\nprintf 'java.base\\n'");
+        writeScript(
+                new File(bin, "jlink"),
+                "printf 'jlink:%s %s\\n' \"$0\" \"$*\" >> '" + log.getAbsolutePath() + "'");
+        File jar = new File(project.getProjectDir(), "app.jar");
+        Files.write(jar.toPath(), new byte[0]);
+
+        CreateRuntimeImageTask task =
+                project.getTasks().create("probeRuntime", CreateRuntimeImageTask.class);
+        task.getJdkRoot().set(targetJdk);
+        task.getTargetJdkRoot().set(targetJdk);
+        task.getModules().set(Collections.emptyList());
+        task.getGuessModulesFromJar().set(true);
+        task.getIncludeDefaultCryptoModules().set(false);
+        task.getStripNativeCommands().set(false);
+        task.getJarFile().set(jar);
+        task.getOutput().set(new File(project.getBuildDir(), "runtime"));
+
+        task.run();
+
+        String invocations = new String(Files.readAllBytes(log.toPath()), StandardCharsets.UTF_8);
+        assertTrue(invocations.contains("javap:" + new File(bin, "javap").getCanonicalPath()));
+        assertTrue(invocations.contains("jdeps:" + new File(bin, "jdeps").getCanonicalPath()));
+        assertTrue(invocations.contains("--multi-release 17"));
+        assertTrue(invocations.contains("jlink:" + new File(bin, "jlink").getCanonicalPath()));
+        assertTrue(invocations.contains("--module-path " + new File(targetJdk, "jmods").getAbsolutePath()));
+    }
+
+    @Test
+    public void packageTasksOwnDistinctArchiveFiles() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        extension.getOutputDir().set(project.getLayout().getProjectDirectory().dir("dist"));
+        createLinuxTarget(extension, "linuxX64");
+        createLinuxTarget(extension, "linuxArm64").getArchitecture().set(Target.Architecture.AARCH64);
+
+        PackageTask x64 = (PackageTask) project.getTasks().getByName("packageLinuxX64");
+        PackageTask arm64 = (PackageTask) project.getTasks().getByName("packageLinuxArm64");
+        File x64Archive = property(x64, "getArchiveFile", RegularFileProperty.class).get().getAsFile();
+        File arm64Archive = property(arm64, "getArchiveFile", RegularFileProperty.class).get().getAsFile();
+
+        assertEquals(new File(project.getProjectDir(), "dist/game-linuxX64.zip"), x64Archive);
+        assertEquals(new File(project.getProjectDir(), "dist/game-linuxArm64.zip"), arm64Archive);
+        assertNotEquals(x64Archive, arm64Archive);
+    }
+
+    @Test
+    public void legacyPackageTaskOutputPropertiesStillControlArchive() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        createLinuxTarget(extension, "linuxX64");
+
+        PackageTask packageTask =
+                (PackageTask) project.getTasks().getByName("packageLinuxX64");
+        packageTask
+                .getDestinationDirectory()
+                .set(project.getLayout().getProjectDirectory().dir("custom-dist"));
+        packageTask.getArchiveFileName().set("custom.zip");
+
+        assertEquals(
+                new File(project.getProjectDir(), "custom-dist/custom.zip"),
+                packageTask.getArchiveFile().get().getAsFile());
+    }
+
+    @Test
+    public void rawMacPackageUsesTheFlatRoastLayout() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        Target.MacOs target = extension.getTargets().create("macosArm64", Target.MacOs.class);
+        target.getArchitecture().set(Target.Architecture.AARCH64);
+        target.getJdkUrl().set("https://example.test/jdk.tar.gz");
+        property(target, "getAppBundle", Property.class).set(false);
+
+        PackageTask packageTask = (PackageTask) project.getTasks().getByName("packageMacosArm64");
+        Set<String> dependencies =
+                packageTask.getTaskDependencies().getDependencies(packageTask).stream()
+                        .map(Task::getName)
+                        .collect(Collectors.toSet());
+
+        assertTrue(dependencies.contains("roastMacosArm64"));
+        assertFalse(dependencies.contains("buildMacAppBundleMacosArm64"));
+        assertFalse(dependencies.contains("generatePListMacosArm64"));
+        assertTrue(packageTask.getFrom().get().getAsFile().getPath().endsWith("macosArm64/roast"));
+        assertFalse(packageTask.getInto().isPresent());
+        assertTrue(packageTask.getExecutable().get().getAsFile().getPath().endsWith("macosArm64/roast/game"));
+    }
+
+    @Test
+    public void rawMacPackageArchiveHasNoAppBundle() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        Target.MacOs target = extension.getTargets().create("macosArm64", Target.MacOs.class);
+        target.getArchitecture().set(Target.Architecture.AARCH64);
+        target.getJdkUrl().set("https://example.test/jdk.tar.gz");
+        property(target, "getAppBundle", Property.class).set(false);
+
+        PackageTask packageTask = (PackageTask) project.getTasks().getByName("packageMacosArm64");
+        File packageRoot = packageTask.getFrom().get().getAsFile();
+        assertTrue(new File(packageRoot, "app").mkdirs());
+        assertTrue(new File(packageRoot, "runtime").mkdirs());
+        Files.write(new File(packageRoot, "game").toPath(), "launcher".getBytes(StandardCharsets.UTF_8));
+        Files.write(new File(packageRoot, "app/game.json").toPath(), "{}".getBytes(StandardCharsets.UTF_8));
+        Files.write(new File(packageRoot, "runtime/release").toPath(), "JAVA_VERSION=17".getBytes(StandardCharsets.UTF_8));
+        File archive = new File(project.getProjectDir(), "raw-mac.zip");
+        packageTask.getArchiveFile().set(archive);
+        packageTask.run();
+
+        try (ZipFile zip = new ZipFile(archive)) {
+            assertNotNull(zip.getEntry("game"));
+            assertNotNull(zip.getEntry("app/game.json"));
+            assertNotNull(zip.getEntry("runtime/release"));
+            assertFalse(zip.stream().anyMatch(entry -> entry.getName().contains(".app/Contents")));
+        }
+    }
+
+    @Test
+    public void verifiedDownloadsGateBothExtractions() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        Target.Linux target = createLinuxTarget(extension, "linuxX64");
+        property(target, "getJdkSha256", Property.class).set(repeat("a", 64));
+        property(target, "getRoastSha256", Property.class).set(repeat("b", 64));
+
+        Task verifyJdk = project.getTasks().getByName("verifyJdkLinuxX64");
+        Task verifyRoast = project.getTasks().getByName("verifyRoastLinuxX64");
+        Task unzipJdk = project.getTasks().getByName("unzipJdkLinuxX64");
+        Task unzipRoast = project.getTasks().getByName("unzipRoastLinuxX64");
+
+        assertTrue(taskDependencyNames(unzipJdk).contains(verifyJdk.getName()));
+        assertTrue(taskDependencyNames(unzipRoast).contains(verifyRoast.getName()));
+    }
+
+    @Test
+    public void targetJdkExtractionRetainsLegalFiles() throws Exception {
+        File project = temporaryFolder.newFolder();
+        File archive = new File(project, "build/construo/jdk/linuxX64.zip");
+        assertTrue(archive.getParentFile().mkdirs());
+        writeZip(archive, "fake-jdk/bin/java", "java", "fake-jdk/legal/java.base/LICENSE", "license");
+        Files.write(new File(project, "settings.gradle").toPath(), "rootProject.name = 'probe'\n".getBytes(StandardCharsets.UTF_8));
+        String buildScript =
+                "import io.github.fourlastor.construo.Target\n"
+                        + "plugins { id 'java'; id 'io.github.fourlastor.construo' }\n"
+                        + "construo {\n"
+                        + "  name = 'probe'\n"
+                        + "  mainClass = 'example.Main'\n"
+                        + "  targets.create('linuxX64', Target.Linux) {\n"
+                        + "    architecture = Target.Architecture.X86_64\n"
+                        + "    jdkUrl = 'https://not-used.example.test/jdk.zip'\n"
+                        + "    jdkSha256 = '" + sha256(archive) + "'\n"
+                        + "  }\n"
+                        + "}\n"
+                        + "tasks.named('downloadJdkLinuxX64') { onlyIf { false } }\n";
+        Files.write(new File(project, "build.gradle").toPath(), buildScript.getBytes(StandardCharsets.UTF_8));
+
+        GradleRunner.create()
+                .withProjectDir(project)
+                .withPluginClasspath()
+                .withArguments("unzipJdkLinuxX64", "--stacktrace")
+                .build();
+
+        assertTrue(new File(project, "build/construo/jdk/linuxX64/legal/java.base/LICENSE").isFile());
+    }
+
+    private Project newProject() throws Exception {
+        Project project =
+                ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+        project.getPluginManager().apply(JavaPlugin.class);
+        project.getPluginManager().apply(ConstruoPlugin.class);
+        ConstruoPluginExtension extension = extension(project);
+        extension.getName().set("game");
+        extension.getMainClass().set("example.Main");
+        return project;
+    }
+
+    private static ConstruoPluginExtension extension(Project project) {
+        return project.getExtensions().getByType(ConstruoPluginExtension.class);
+    }
+
+    private static Target.Linux createLinuxTarget(ConstruoPluginExtension extension, String name) {
+        Target.Linux target = extension.getTargets().create(name, Target.Linux.class);
+        target.getArchitecture().set(Target.Architecture.X86_64);
+        target.getJdkUrl().set("https://example.test/jdk.tar.gz");
+        return target;
+    }
+
+    private static Method assertGetter(Class<?> type, String name) {
+        try {
+            return type.getMethod(name);
+        } catch (NoSuchMethodException error) {
+            fail(type.getSimpleName() + " is missing " + name + "(); found "
+                    + Arrays.stream(type.getMethods()).map(Method::getName).sorted().collect(Collectors.toList()));
+            throw new AssertionError(error);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T property(Object owner, String getter, Class<T> type) {
+        try {
+            Object value = assertGetter(owner.getClass(), getter).invoke(owner);
+            return (T) type.cast(value);
+        } catch (IllegalAccessException | InvocationTargetException error) {
+            throw new AssertionError("Could not read " + getter + " from " + owner, error);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void setEnumProperty(Object owner, String getter, String value) throws Exception {
+        Property property = property(owner, getter, Property.class);
+        Class<? extends Enum> enumType =
+                (Class<? extends Enum>) Class.forName(Target.class.getName() + "$PackagingToolJdk");
+        property.set(Enum.valueOf(enumType, value));
+    }
+
+    private static String executable(String path) {
+        return System.getProperty("os.name").startsWith("Windows") ? path + ".exe" : path;
+    }
+
+    private static Set<String> taskDependencyNames(Task task) {
+        return task.getTaskDependencies().getDependencies(task).stream()
+                .map(Task::getName)
+                .collect(Collectors.toSet());
+    }
+
+    private static String repeat(String value, int count) {
+        StringBuilder result = new StringBuilder(value.length() * count);
+        for (int index = 0; index < count; index++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+
+    private static void writeZip(File archive, String... pathsAndContents) throws Exception {
+        try (ZipOutputStream output = new ZipOutputStream(new FileOutputStream(archive))) {
+            for (int index = 0; index < pathsAndContents.length; index += 2) {
+                output.putNextEntry(new ZipEntry(pathsAndContents[index]));
+                output.write(pathsAndContents[index + 1].getBytes(StandardCharsets.UTF_8));
+                output.closeEntry();
+            }
+        }
+    }
+
+    private static void writeScript(File script, String body) throws Exception {
+        Files.write(script.toPath(), ("#!/bin/sh\nset -eu\n" + body + "\n").getBytes(StandardCharsets.UTF_8));
+        assertTrue(script.setExecutable(true));
+    }
+
+    private static String sha256(File file) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(file.toPath()));
+        StringBuilder result = new StringBuilder(digest.length * 2);
+        for (byte value : digest) {
+            result.append(String.format("%02x", value));
+        }
+        return result.toString();
+    }
+}

--- a/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/ConstruoPluginContractTest.java
@@ -80,6 +80,14 @@ public class ConstruoPluginContractTest {
     }
 
     @Test
+    public void roastDefaultsToLatestCompatibleRelease() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+
+        assertEquals("v1.6.0", property(extension.getRoast(), "getVersion", Property.class).get());
+    }
+
+    @Test
     public void targetJdkCanProvideAllPackagingTools() throws Exception {
         Project project = newProject();
         ConstruoPluginExtension extension = extension(project);
@@ -253,6 +261,19 @@ public class ConstruoPluginContractTest {
 
         assertTrue(taskDependencyNames(unzipJdk).contains(verifyJdk.getName()));
         assertTrue(taskDependencyNames(unzipRoast).contains(verifyRoast.getName()));
+    }
+
+    @Test
+    public void downloadsWithoutDigestsSkipVerification() throws Exception {
+        Project project = newProject();
+        ConstruoPluginExtension extension = extension(project);
+        createLinuxTarget(extension, "linuxX64");
+
+        Task unzipJdk = project.getTasks().getByName("unzipJdkLinuxX64");
+        Task unzipRoast = project.getTasks().getByName("unzipRoastLinuxX64");
+
+        assertFalse(taskDependencyNames(unzipJdk).contains("verifyJdkLinuxX64"));
+        assertFalse(taskDependencyNames(unzipRoast).contains("verifyRoastLinuxX64"));
     }
 
     @Test

--- a/construo/src/test/java/io/github/fourlastor/construo/ExtractJdkTaskTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/ExtractJdkTaskTest.java
@@ -1,0 +1,52 @@
+package io.github.fourlastor.construo;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.github.fourlastor.construo.task.ExtractJdkTask;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ExtractJdkTaskTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void replacesStaleOutputWithOnlyVerifiedArchiveContents() throws Exception {
+        Project project =
+                ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+        File archive = new File(project.getProjectDir(), "jdk.zip");
+        writeZip(archive, "jdk/bin/java", "java", "jdk/release", "JAVA_VERSION=17");
+        File output = new File(project.getBuildDir(), "jdk");
+        assertTrue(output.mkdirs());
+        Files.write(new File(output, "obsolete.txt").toPath(), "stale".getBytes(StandardCharsets.UTF_8));
+
+        ExtractJdkTask task = project.getTasks().create("extractJdk", ExtractJdkTask.class);
+        task.getArchive().set(archive);
+        task.getOutputDirectory().set(output);
+        task.run();
+
+        assertFalse(new File(output, "obsolete.txt").exists());
+        assertTrue(new File(output, "bin/java").isFile());
+        assertTrue(new File(output, "release").isFile());
+    }
+
+    private static void writeZip(File archive, String... pathsAndContents) throws Exception {
+        try (ZipOutputStream output = new ZipOutputStream(new FileOutputStream(archive))) {
+            for (int index = 0; index < pathsAndContents.length; index += 2) {
+                output.putNextEntry(new ZipEntry(pathsAndContents[index]));
+                output.write(pathsAndContents[index + 1].getBytes(StandardCharsets.UTF_8));
+                output.closeEntry();
+            }
+        }
+    }
+}

--- a/construo/src/test/java/io/github/fourlastor/construo/PackageTaskSecurityTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/PackageTaskSecurityTest.java
@@ -1,0 +1,164 @@
+package io.github.fourlastor.construo;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.github.fourlastor.construo.task.PackageTask;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Collections;
+import java.util.zip.ZipFile;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class PackageTaskSecurityTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void rejectsPackageFileDestinationsOutsideTheDistribution() throws Exception {
+        for (String destination :
+                Arrays.asList("../escape.txt", "safe/../../escape.txt", "/absolute.txt", "C:\\absolute.txt")) {
+            Project project =
+                    ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+            File input = new File(project.getProjectDir(), "input");
+            assertTrue(input.mkdirs());
+            File launcher = new File(input, "launcher");
+            Files.write(launcher.toPath(), "launcher".getBytes(StandardCharsets.UTF_8));
+            File extra = new File(project.getProjectDir(), "extra.txt");
+            Files.write(extra.toPath(), "extra".getBytes(StandardCharsets.UTF_8));
+            File archive = new File(project.getProjectDir(), "output/package.zip");
+
+            PackageTask task = project.getTasks().create("packageApp", PackageTask.class);
+            task.getFrom().set(input);
+            task.getExecutable().set(launcher);
+            task.getArchiveFile().set(archive);
+            task.getPackageFiles()
+                    .set(Collections.singletonMap(destination, project.getLayout().getProjectDirectory().file("extra.txt")));
+
+            try {
+                task.run();
+                fail("Expected destination to be rejected: " + destination);
+            } catch (IllegalArgumentException expected) {
+                assertTrue(expected.getMessage().contains(destination));
+            }
+            assertFalse("Invalid mappings must not leave an archive", archive.exists());
+        }
+    }
+
+    @Test
+    public void rejectsArchiveRootOutsideTheDistribution() throws Exception {
+        Project project =
+                ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+        File input = new File(project.getProjectDir(), "input");
+        assertTrue(input.mkdirs());
+        File launcher = new File(input, "launcher");
+        Files.write(launcher.toPath(), "launcher".getBytes(StandardCharsets.UTF_8));
+        File archive = new File(project.getProjectDir(), "output/package.zip");
+
+        PackageTask task = project.getTasks().create("packageApp", PackageTask.class);
+        task.getFrom().set(input);
+        task.getExecutable().set(launcher);
+        task.getArchiveFile().set(archive);
+        task.getPackageFiles().set(Collections.emptyMap());
+        task.getInto().set("../escape");
+
+        try {
+            task.run();
+            fail("Expected archive root to be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("../escape"));
+        }
+        assertFalse("Invalid archive roots must not leave an archive", archive.exists());
+    }
+
+    @Test
+    public void normalizesWindowsSeparatorsInArchiveEntries() throws Exception {
+        Project project =
+                ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+        File input = new File(project.getProjectDir(), "input");
+        assertTrue(input.mkdirs());
+        File launcher = new File(input, "launcher");
+        Files.write(launcher.toPath(), "launcher".getBytes(StandardCharsets.UTF_8));
+        File extra = new File(project.getProjectDir(), "extra.txt");
+        Files.write(extra.toPath(), "extra".getBytes(StandardCharsets.UTF_8));
+        File archive = new File(project.getProjectDir(), "output/package.zip");
+
+        PackageTask task = project.getTasks().create("packageApp", PackageTask.class);
+        task.getFrom().set(input);
+        task.getExecutable().set(launcher);
+        task.getArchiveFile().set(archive);
+        task.getPackageFiles()
+                .set(Collections.singletonMap(
+                        "runtime\\extra.txt",
+                        project.getLayout().getProjectDirectory().file("extra.txt")));
+        task.run();
+
+        try (ZipFile zip = new ZipFile(archive)) {
+            assertNotNull(zip.getEntry("runtime/extra.txt"));
+        }
+    }
+
+    @Test
+    public void rejectsDuplicateLogicalDestinationsWithMixedSeparators() throws Exception {
+        Project project =
+                ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+        File input = new File(project.getProjectDir(), "input");
+        assertTrue(input.mkdirs());
+        File launcher = new File(input, "launcher");
+        Files.write(launcher.toPath(), "launcher".getBytes(StandardCharsets.UTF_8));
+        Files.write(new File(project.getProjectDir(), "one.txt").toPath(), "one".getBytes(StandardCharsets.UTF_8));
+        Files.write(new File(project.getProjectDir(), "two.txt").toPath(), "two".getBytes(StandardCharsets.UTF_8));
+        File archive = new File(project.getProjectDir(), "output/package.zip");
+
+        PackageTask task = project.getTasks().create("packageApp", PackageTask.class);
+        task.getFrom().set(input);
+        task.getExecutable().set(launcher);
+        task.getArchiveFile().set(archive);
+        Map<String, org.gradle.api.file.RegularFile> mappings = new LinkedHashMap<>();
+        mappings.put("runtime/extra.txt", project.getLayout().getProjectDirectory().file("one.txt"));
+        mappings.put("runtime\\extra.txt", project.getLayout().getProjectDirectory().file("two.txt"));
+        task.getPackageFiles().set(mappings);
+
+        try {
+            task.run();
+            fail("Expected duplicate logical destinations to be rejected");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("Duplicate package entry"));
+        }
+    }
+
+    @Test
+    public void rejectsArchiveInsideInputTree() throws Exception {
+        Project project =
+                ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+        File input = new File(project.getProjectDir(), "input");
+        assertTrue(input.mkdirs());
+        File launcher = new File(input, "launcher");
+        Files.write(launcher.toPath(), "launcher".getBytes(StandardCharsets.UTF_8));
+        File archive = new File(input, "package.zip");
+
+        PackageTask task = project.getTasks().create("packageApp", PackageTask.class);
+        task.getFrom().set(input);
+        task.getExecutable().set(launcher);
+        task.getArchiveFile().set(archive);
+        task.getPackageFiles().set(Collections.emptyMap());
+
+        try {
+            task.run();
+            fail("Expected archive inside input tree to be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("must not be inside package input"));
+        }
+        assertFalse(archive.exists());
+    }
+}

--- a/construo/src/test/java/io/github/fourlastor/construo/VerifySha256TaskTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/VerifySha256TaskTest.java
@@ -1,0 +1,121 @@
+package io.github.fourlastor.construo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class VerifySha256TaskTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void acceptsTheExpectedDigestAndHasNoOutputs() throws Exception {
+        File archive = temporaryFolder.newFile("archive.zip");
+        Files.write(archive.toPath(), "verified bytes".getBytes(StandardCharsets.UTF_8));
+        Task task = verifyTask(archive, sha256(archive));
+
+        invokeVerify(task);
+
+        assertFalse("Verification must run for warm downloads", task.getOutputs().getHasOutput());
+        Method archiveGetter = taskType().getMethod("getArchive");
+        Method digestGetter = taskType().getMethod("getExpectedSha256");
+        assertNotNull(archiveGetter.getAnnotation(InputFile.class));
+        assertNotNull(digestGetter.getAnnotation(Input.class));
+    }
+
+    @Test
+    public void rejectsAMismatchedDigest() throws Exception {
+        File archive = temporaryFolder.newFile("archive.zip");
+        Files.write(archive.toPath(), "untrusted bytes".getBytes(StandardCharsets.UTF_8));
+        Task task = verifyTask(archive, repeat("0", 64));
+
+        Throwable failure = expectFailure(task);
+
+        assertTrue(failure.getMessage().contains("SHA-256 mismatch"));
+        assertTrue(failure.getMessage().contains(archive.getName()));
+        assertFalse("A mismatched cached archive must be downloaded again", archive.exists());
+    }
+
+    @Test
+    public void rejectsMalformedDigestBeforeReadingTheArchive() throws Exception {
+        File missingArchive = new File(temporaryFolder.getRoot(), "missing.zip");
+        Task task = verifyTask(missingArchive, "not-a-sha256");
+
+        Throwable failure = expectFailure(task);
+
+        assertTrue(failure.getMessage().contains("64 hexadecimal"));
+    }
+
+    private Task verifyTask(File archive, String expectedSha256) throws Exception {
+        Project project =
+                ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+        Class<? extends Task> taskType = taskType();
+        Task task = project.getTasks().create("verifyArchive", taskType);
+        property(task, "getArchive", RegularFileProperty.class).set(archive);
+        property(task, "getExpectedSha256", Property.class).set(expectedSha256);
+        return task;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Task> taskType() throws ClassNotFoundException {
+        return (Class<? extends Task>)
+                Class.forName("io.github.fourlastor.construo.task.VerifySha256Task");
+    }
+
+    private static void invokeVerify(Task task) throws Exception {
+        task.getClass().getMethod("run").invoke(task);
+    }
+
+    private static Throwable expectFailure(Task task) throws Exception {
+        try {
+            invokeVerify(task);
+            fail("Expected SHA-256 verification to fail");
+            throw new AssertionError("unreachable");
+        } catch (InvocationTargetException error) {
+            return error.getCause();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T property(Object owner, String getter, Class<T> type) throws Exception {
+        return (T) type.cast(owner.getClass().getMethod(getter).invoke(owner));
+    }
+
+    private static String sha256(File file) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] bytes = Files.readAllBytes(file.toPath());
+        byte[] result = digest.digest(bytes);
+        StringBuilder hex = new StringBuilder(result.length * 2);
+        for (byte value : result) {
+            hex.append(String.format("%02x", value));
+        }
+        return hex.toString();
+    }
+
+    private static String repeat(String value, int count) {
+        StringBuilder result = new StringBuilder(value.length() * count);
+        for (int index = 0; index < count; index++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+}

--- a/construo/src/test/java/io/github/fourlastor/construo/task/DownloadTaskTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/task/DownloadTaskTest.java
@@ -1,0 +1,80 @@
+package io.github.fourlastor.construo.task;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskExecutionException;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DownloadTaskTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void interruptedDownloadDoesNotLeaveDeclaredOutput() throws Exception {
+        byte[] partialBody = "partial".getBytes(StandardCharsets.UTF_8);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/archive.zip",
+                exchange -> {
+                    exchange.sendResponseHeaders(200, partialBody.length + 100L);
+                    exchange.getResponseBody().write(partialBody);
+                    exchange.close();
+                });
+        server.start();
+        try {
+            Project project =
+                    ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+            DownloadTask task = project.getTasks().create("download", DownloadTask.class);
+            File destination = new File(project.getBuildDir(), "downloads/archive.zip");
+            task.getSrc()
+                    .set("http://127.0.0.1:" + server.getAddress().getPort() + "/archive.zip");
+            task.getDest().set(destination);
+
+            assertThrows(TaskExecutionException.class, task::run);
+            assertFalse(destination.exists());
+            assertFalse(new File(destination.getPath() + ".part").exists());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void successfulDownloadReplacesPartFile() throws Exception {
+        byte[] body = "complete archive".getBytes(StandardCharsets.UTF_8);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/archive.zip",
+                exchange -> {
+                    exchange.sendResponseHeaders(200, body.length);
+                    exchange.getResponseBody().write(body);
+                    exchange.close();
+                });
+        server.start();
+        try {
+            Project project =
+                    ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder()).build();
+            DownloadTask task = project.getTasks().create("download", DownloadTask.class);
+            File destination = new File(project.getBuildDir(), "downloads/archive.zip");
+            task.getSrc()
+                    .set("http://127.0.0.1:" + server.getAddress().getPort() + "/archive.zip");
+            task.getDest().set(destination);
+
+            task.run();
+
+            assertArrayEquals(body, java.nio.file.Files.readAllBytes(destination.toPath()));
+            assertFalse(new File(destination.getPath() + ".part").exists());
+        } finally {
+            server.stop(0);
+        }
+    }
+}

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -44,28 +44,20 @@ construo {
         create<Target.Linux>("linuxX64") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz")
-            jdkSha256.set("7b175dbe0d6e3c9c23b6ed96449b018308d8fc94a5ecd9c0df8b8bc376c3c18a")
-            roastSha256.set("b5567b8a30ec5b6c9fe652e4de9dd455648cc779e3253d04c23df50f04db4ae3")
         }
         create<Target.MacOs>("macX64") {
             architecture.set(Target.Architecture.X86_64)
             identifier.set("io.github.fourlastor.Game")
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_mac_hotspot_17.0.8_7.tar.gz")
-            jdkSha256.set("6fea89cea64a0f56ecb9e5d746b4921d2b0a80aa65c92b265ee9db52b44f4d93")
-            roastSha256.set("1d96878c26c820876198f87a0ebc523818da04372a2dd9e8b19c900a2772f997")
         }
         create<Target.MacOs>("macM1") {
             architecture.set(Target.Architecture.AARCH64)
             identifier.set("io.github.fourlastor.Game")
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.8_7.tar.gz")
-            jdkSha256.set("105d1ada42927fccde215e8c80b43221cd5aad42e6183819c367234ac062fc10")
-            roastSha256.set("33ad8745576260d8e006705ee111af35ae7b0c1ff48eaf783f39bbec9d6cc54d")
         }
         create<Target.Windows>("winX64") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8_7.zip")
-            jdkSha256.set("341a7243778802019a100ba7ae32a05a3f4ae5fd64dbf2a970d02f07c7d1c804")
-            roastSha256.set("59fc0b82638dc9b67864b0a1157ec8d0b43f856e3c85e94e5eeeb13a9b38fa99")
             if (providers.gradleProperty("useTargetJdkTools").isPresent) {
                 packagingToolJdk.set(Target.PackagingToolJdk.TARGET_JDK)
             }
@@ -73,8 +65,6 @@ construo {
         create<Target.Windows>("winX64NoGpu") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8_7.zip")
-            jdkSha256.set("341a7243778802019a100ba7ae32a05a3f4ae5fd64dbf2a970d02f07c7d1c804")
-            roastSha256.set("79ce74f26ebaa468618e752c0a0dd3a534c17f89d3c0859357e7fadd634e9270")
             useGpuHint.set(false)
         }
     }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -44,24 +44,37 @@ construo {
         create<Target.Linux>("linuxX64") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz")
+            jdkSha256.set("7b175dbe0d6e3c9c23b6ed96449b018308d8fc94a5ecd9c0df8b8bc376c3c18a")
+            roastSha256.set("b5567b8a30ec5b6c9fe652e4de9dd455648cc779e3253d04c23df50f04db4ae3")
         }
         create<Target.MacOs>("macX64") {
             architecture.set(Target.Architecture.X86_64)
             identifier.set("io.github.fourlastor.Game")
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_mac_hotspot_17.0.8_7.tar.gz")
+            jdkSha256.set("6fea89cea64a0f56ecb9e5d746b4921d2b0a80aa65c92b265ee9db52b44f4d93")
+            roastSha256.set("1d96878c26c820876198f87a0ebc523818da04372a2dd9e8b19c900a2772f997")
         }
         create<Target.MacOs>("macM1") {
             architecture.set(Target.Architecture.AARCH64)
             identifier.set("io.github.fourlastor.Game")
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.8_7.tar.gz")
+            jdkSha256.set("105d1ada42927fccde215e8c80b43221cd5aad42e6183819c367234ac062fc10")
+            roastSha256.set("33ad8745576260d8e006705ee111af35ae7b0c1ff48eaf783f39bbec9d6cc54d")
         }
         create<Target.Windows>("winX64") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8_7.zip")
+            jdkSha256.set("341a7243778802019a100ba7ae32a05a3f4ae5fd64dbf2a970d02f07c7d1c804")
+            roastSha256.set("59fc0b82638dc9b67864b0a1157ec8d0b43f856e3c85e94e5eeeb13a9b38fa99")
+            if (providers.gradleProperty("useTargetJdkTools").isPresent) {
+                packagingToolJdk.set(Target.PackagingToolJdk.TARGET_JDK)
+            }
         }
         create<Target.Windows>("winX64NoGpu") {
             architecture.set(Target.Architecture.X86_64)
             jdkUrl.set("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8_7.zip")
+            jdkSha256.set("341a7243778802019a100ba7ae32a05a3f4ae5fd64dbf2a970d02f07c7d1c804")
+            roastSha256.set("79ce74f26ebaa468618e752c0a0dd3a534c17f89d3c0859357e7fadd634e9270")
             useGpuHint.set(false)
         }
     }


### PR DESCRIPTION
## Executive summary

Construo packages JVM applications into self-contained, platform-specific ZIPs. Before this PR,
several important distribution choices were implicit: Construo selected a fixed Roast release,
trusted downloaded archives without verifying them, normally ran packaging tools from the build
machine's JDK, derived archive locations from a shared output directory, and always produced a
macOS app bundle. Those assumptions work for the original application flow, but they make it hard
to build reproducible native command-line distributions for several operating systems.

This PR turns those assumptions into an explicit **per-target distribution contract**. A Linux,
macOS, or Windows target can now:

- pin the exact JDK and Roast artifacts it consumes and verify both with SHA-256 before extraction;
- choose whether `jlink`/`jdeps` come from the host JDK or the downloaded target JDK;
- choose the exact output ZIP path independently of other targets;
- override the Roast artifact for a specific target; and
- produce either a normal macOS `.app` bundle or a raw command-line layout.

Downloads are replaced atomically, invalid or stale extractions are cleaned up, and archive paths
are rejected if they are absolute, escape the distribution, collide, overwrite an input, or place
the output inside the directory being packaged. This makes failures early and explicit instead of
producing a package from the wrong or partially downloaded inputs.

Existing consumers keep the compatibility defaults: host-JDK packaging tools, macOS app bundles,
and the existing output-directory/archive-name configuration continue to work. This is generic
Construo infrastructure rather than application-specific behavior: a consumer such as
`kotlin-code-index` supplies its pinned artifacts and target choices, while Construo performs the
verified download, extraction, runtime construction, and packaging.

This is intentionally separate from #111/#112. It does **not** change their completed runtime-image,
generated-file/task-dependency, or ZIP permission contracts, and it adds no AOT- or
timestamp-specific behavior.

## Technical summary

- add configurable Roast release coordinates and target-specific URL overrides
- verify pinned JDK and Roast SHA-256 digests before extraction, with atomic downloads and retry-safe mismatch cleanup
- add deterministic per-target archive outputs and a target-selectable packaging JDK
- support raw macOS CLI archives while keeping app bundles and host tools as compatibility defaults
- retain JDK legal files and harden package paths/output isolation
- make the distribution task graph configuration-cache safe

## Verification

- `construo/gradlew clean check spotlessCheck`
- root `./gradlew clean check spotlessCheck`
- package graph configuration cache stored and reused
- real macOS arm64 package built under the verified JDK 17, extracted with `ditto`, and launched successfully (exit 0)
- focused red/green coverage for checksum failures, interrupted downloads, traversal/collision rejection, legacy archive setters, raw mac layout, legal-file retention, and stale extraction cleanup
- read-only contract, Gradle/task-graph, and security/cross-platform review stacks passed

Windows CI now packages with the downloaded target JDK tools, extracts the resulting ZIP with PowerShell, and launches the executable.
