### PR TITLE
RoastTask: preserve staged application JAR timestamps

### DIFF
--- a/construo/src/main/java/io/github/fourlastor/construo/task/jvm/RoastTask.kt
+++ b/construo/src/main/java/io/github/fourlastor/construo/task/jvm/RoastTask.kt
@@ -15,6 +15,8 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import javax.inject.Inject
 
 abstract class RoastTask @Inject constructor(
@@ -91,10 +93,13 @@ abstract class RoastTask @Inject constructor(
             into(output.dir("runtime"))
         }
 
-        fileSystemOperations.copy {
-            from(jarFile)
-            into(output)
-        }
+        val applicationJar = jarFile.get().asFile
+        Files.copy(
+            applicationJar.toPath(),
+            outputDir.resolve(applicationJar.name).toPath(),
+            StandardCopyOption.COPY_ATTRIBUTES,
+            StandardCopyOption.REPLACE_EXISTING,
+        )
     }
 
     @Serializable

--- a/construo/src/test/java/io/github/fourlastor/construo/RoastTaskTest.java
+++ b/construo/src/test/java/io/github/fourlastor/construo/RoastTaskTest.java
@@ -1,0 +1,55 @@
+package io.github.fourlastor.construo;
+
+import static org.junit.Assert.assertEquals;
+
+import io.github.fourlastor.construo.task.jvm.RoastTask;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
+import java.util.Collections;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class RoastTaskTest {
+
+    private static final long NORMALIZED_JAR_MTIME_MILLIS = 1_700_000_000_000L;
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void preservesTheApplicationJarTimestamp() throws Exception {
+        File projectDirectory = temporaryFolder.newFolder("project");
+        Project project = ProjectBuilder.builder().withProjectDir(projectDirectory).build();
+        File runtime = temporaryFolder.newFolder("runtime");
+        Files.write(new File(runtime, "release").toPath(), new byte[] {0});
+        File jar = temporaryFolder.newFile("indexino-cli.jar");
+        Files.write(jar.toPath(), "application".getBytes(StandardCharsets.UTF_8));
+        Files.setLastModifiedTime(jar.toPath(), FileTime.fromMillis(NORMALIZED_JAR_MTIME_MILLIS));
+        File launcher = temporaryFolder.newFile("roast-macos-aarch64");
+        Files.write(launcher.toPath(), "launcher".getBytes(StandardCharsets.UTF_8));
+        File output = new File(projectDirectory, "build/roast");
+
+        RoastTask task = project.getTasks().create("roast", RoastTask.class);
+        task.getJdkRoot().set(runtime);
+        task.getAppName().set("indexino");
+        task.getMainClassName().set("example.Main");
+        task.getRoastExe().set(launcher);
+        task.getRoastExeName().set("indexino");
+        task.getJarFile().set(jar);
+        task.getRunOnFirstThread().set(true);
+        task.getVmArgs().set(Collections.emptyList());
+        task.getUseZgc().set(false);
+        task.getUseMainAsContextClassLoader().set(false);
+        task.getOutput().set(output);
+
+        task.run();
+
+        assertEquals(
+                NORMALIZED_JAR_MTIME_MILLIS,
+                Files.getLastModifiedTime(new File(output, jar.getName()).toPath()).toMillis());
+    }
+}


### PR DESCRIPTION
## Executive summary

Construo currently changes the application JAR's filesystem timestamp while copying it into Roast staging. JDK AOT validates that metadata, so a cache trained against a normalized source JAR is rejected after the restamped JAR is packaged and extracted.

This PR makes the staging copy preserve file attributes. It changes no DSL, task graph, archive layout, or application contents.

## Summary

- Copy the application JAR with `COPY_ATTRIBUTES` and `REPLACE_EXISTING` instead of Gradle's generic copy operation.
- Add a focused `RoastTask` regression test using an exact deterministic JAR mtime.
- Keep the existing Gradle copy behavior for the launcher and runtime directories.

## Testing

- [x] New test failed before the implementation because the staged JAR received the current time.
- [x] `./gradlew :construo:test --tests io.github.fourlastor.construo.RoastTaskTest`
- [x] `construo/gradlew clean check spotlessCheck`
- [x] Root `./gradlew clean check spotlessCheck`
- [x] Composite-build proof with Indexino: built the real macOS arm64 archive and verified its `indexino-cli.jar` ZIP timestamp exactly matches the normalized source JAR timestamp (`1700000000000`).

## Risks

- Low: the change is limited to the single application-JAR copy inside `RoastTask`.
- A copy-attribute failure now fails the packaging task instead of silently producing metadata that can invalidate AOT.

## Scope

- In scope: preserve application-JAR filesystem metadata through Roast staging.
- Out of scope: AOT-specific DSL, timestamp normalization policy, archive format changes, or downstream task mutations.
